### PR TITLE
Python 3 Compatibility

### DIFF
--- a/sphinxcontrib/youtube/youtube.py
+++ b/sphinxcontrib/youtube/youtube.py
@@ -1,6 +1,13 @@
 #-*- coding:utf-8 -*-
 
-import urlparse
+#Import urlparse in Python 2 or urllib.parse in Python 3
+
+try:
+    import urlparse
+
+except ImportError:
+    import urllib.parse as urlparse
+
 
 from docutils import nodes
 from docutils.parsers import rst


### PR DESCRIPTION
Urlparse has been renamed to urllib.parse in Python 3. This little modification makes it possible to use the extension with Python 3.
