### PR TITLE
Syntax change: Use video ID instead of URL

### DIFF
--- a/sphinxcontrib/youtube/youtube.py
+++ b/sphinxcontrib/youtube/youtube.py
@@ -12,18 +12,9 @@ class youtube(nodes.General, nodes.Element):
 
 
 
-def get_video_id(url):
-
-    return urlparse.parse_qs(urlparse.urlparse(url).query)['v'][0]
-
-
-
-
 def visit(self, node):
 
-    video_id = get_video_id(node.url)
-
-    url = u'//www.youtube.com/embed/{0}?feature=player_detailpage'.format(video_id)
+    url = u'//www.youtube.com/embed/{0}?feature=player_detailpage'.format(node.video_id)
 
     tag = u'''<iframe width="640" height="360" src="{0}" frameborder="0" allowfullscreen="1">&nbsp;</iframe>'''.format(url)
 
@@ -52,7 +43,7 @@ class YoutubeDirective(rst.Directive):
 
         node = self.node_class()
 
-        node.url = self.arguments[0]
+        node.video_id = self.arguments[0]
 
         return [node]
 


### PR DESCRIPTION
I have proposal: lets use video ID instead the full URL:

```.. youtube:: f00BarSPaM```

This makes the code cleaner and allows to eliminate the ```get_video_id``` function from the code.

Also, it makes your syntax more compatible with the one used in the youtube extension in the sphinx-contrib repo: https://bitbucket.org/birkenfeld/sphinx-contrib/src/940757f22e335f6ae98521621201683d6bab1d60/youtube/?at=default